### PR TITLE
DownloadManager: Refactor

### DIFF
--- a/app/src/main/java/com/nevilleantony/prototype/downloadmanager/DownloadRepo.java
+++ b/app/src/main/java/com/nevilleantony/prototype/downloadmanager/DownloadRepo.java
@@ -30,6 +30,7 @@ public class DownloadRepo {
                 FileDownload fileDownload = new FileDownload(
                         model.getId(),
                         model.getFile_url(),
+                        model.getFile_name(),
                         model.getRange(),
                         model.getMin_range(),
                         model.getMax_range(),
@@ -86,6 +87,7 @@ public class DownloadRepo {
         downloadMap.put(groupId, new FileDownload(
                 groupId,
                 url,
+                fileName,
                 range,
                 minRange,
                 maxRange,

--- a/app/src/main/java/com/nevilleantony/prototype/downloadmanager/FileDownload.java
+++ b/app/src/main/java/com/nevilleantony/prototype/downloadmanager/FileDownload.java
@@ -59,11 +59,11 @@ public class FileDownload {
     }
 
 
-    public void startDownload(Context context) throws IOException {
+    public void startDownload(Context context) {
         state = DownloadState.RUNNING;
 
         for (OnStateChangedCallback callback : onStateChangedCallbacks) {
-            callback.onDownloadStarted();
+            callback.onStateChanged(state);
         }
         handler.post(
                 () -> {
@@ -134,7 +134,7 @@ public class FileDownload {
         state = DownloadState.PAUSED;
 
         for (OnStateChangedCallback callback : onStateChangedCallbacks) {
-            callback.onDownloadPaused(progress);
+            callback.onStateChanged(state);
         }
     }
 
@@ -150,13 +150,31 @@ public class FileDownload {
         NOT_STARTED,
         RUNNING,
         PAUSED,
-        COMPLETED
+        COMPLETED;
+
+        public static String getNotificationAction(DownloadState state) {
+            String action;
+
+            switch (state) {
+                case NOT_STARTED:
+                    action = "Start";
+                    break;
+                case RUNNING:
+                    action = "Pause";
+                    break;
+                case PAUSED:
+                    action = "Resume";
+                    break;
+                default:
+                    action = "";
+            }
+
+            return action;
+        }
     }
 
     interface OnStateChangedCallback {
-        void onDownloadStarted();
-
-        void onDownloadPaused(int progress);
+        void onStateChanged(DownloadState state);
 
         void onDownloadComplete();
 

--- a/app/src/main/java/com/nevilleantony/prototype/downloadmanager/NotificationReceiver.java
+++ b/app/src/main/java/com/nevilleantony/prototype/downloadmanager/NotificationReceiver.java
@@ -17,11 +17,7 @@ public class NotificationReceiver extends BroadcastReceiver {
         if (fileDownload.getState() == FileDownload.DownloadState.RUNNING) {
             fileDownload.pauseDownload();
         } else if (fileDownload.getState() == FileDownload.DownloadState.PAUSED) {
-            try {
-                fileDownload.startDownload(context);
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+            fileDownload.startDownload(context);
         }
     }
 }


### PR DESCRIPTION
Fix notification text not updating on pause/resume
Only update notification every 500ms
Use a single `onStateChanged(DownloadState)` instead of separate callbacks for pause and resume
Add helper method to get action name for `DownloadState`
Expose final properties such as groupId, fileName, fileUrl